### PR TITLE
Fix issue with getting all team outcomes

### DIFF
--- a/tpg/tpg_trainer.py
+++ b/tpg/tpg_trainer.py
@@ -186,9 +186,9 @@ class TpgTrainer:
         # get outcomes of all teams outcome[team][tasknum]
         for team in self.rootTeams:
             teamScoresMap[team] = [0]*len(self.tasks)
-            for t in range(len(self.tasks)):
-                teamScoresMap[team][t] = team.outcomes[self.tasks[t]]
-                taskTotalScores[t] += team.outcomes[self.tasks[t]]#up task total
+            for t, task in enumerate(self.tasks):
+                teamScoresMap[team][t] = team.outcomes[task]
+                taskTotalScores[t] += team.outcomes[task]#up task total
 
         scores = []
         if fitShare: # fitness share across all outcomes


### PR DESCRIPTION
Fixes this issue:
```
  File "/usr/local/lib/python3.6/site-packages/tpg/tpg_trainer.py", line 169, in evolve
    self.select(fitShare=fitShare)
  File "/usr/local/lib/python3.6/site-packages/tpg/tpg_trainer.py", line 190, in select
    teamScoresMap[team][t] = team.outcomes[self.tasks[t]]
TypeError: 'set' object does not support indexing
```