### PR TITLE
Fix issue iterating over team tuple when deleting

### DIFF
--- a/tpg/tpg_trainer.py
+++ b/tpg/tpg_trainer.py
@@ -206,7 +206,7 @@ class TpgTrainer:
         delTeams = scores[numKeep:] # teams to get rid of
 
         # properly delete the teams
-        for team in delTeams:
+        for team,_ in delTeams:
             team.erase()
             self.teams.remove(team)
             self.rootTeams.remove(team)


### PR DESCRIPTION
`delTeams` is a list of tuples in the form (team, score). This change will break up the tuple, and ignore the second value (score). 